### PR TITLE
Add solve CLI with integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        uses: actions/setup-rust@v1
+        uses: actions/setup-rust@v2
         with:
           rust-version: stable
       - name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        uses: actions/setup-rust@v2
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true      
       - name: Format
         run: cargo fmt -- --check
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Format
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: cargo test -q

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ This crate provides a simple Sudoku solver that records which solving strategies
 use sudoku_evaluator::{board::Board, Solver};
 
 let puzzle = "53467891267219534819834256785976142342685379171392485696153728428741963534528617.";
-let mut board = Board::from_str(puzzle).unwrap();
+let mut board = Board::parse(puzzle).unwrap();
 let solver = Solver::default();
 let used = solver.solve(&mut board).unwrap();
 assert!(board.is_solved());
 println!("Strategies used: {:?}", used);
 ```
+
+### Command line usage
+
+Build and run the `solve` binary to solve a puzzle from the command line:
+
+```
+cargo run --bin solve -- "530070000600195000098000060800060003400803001700020006060000280000419005000080079"
+```
+
+The program prints the strategies that were required and the solved board.
 
 Run tests with `cargo test`.
 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input).unwrap();
     let puzzle: String = input.chars().filter(|c| !c.is_whitespace()).collect();
-    let mut board = Board::from_str(&puzzle).unwrap();
+    let mut board = Board::parse(&puzzle).unwrap();
     let solver = Solver::default();
     let res = solver.solve(&mut board);
     println!("res: {:?}", res);

--- a/src/bin/evaluator.rs
+++ b/src/bin/evaluator.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         buf
     };
     let puzzle: String = input.chars().filter(|c| !c.is_whitespace()).collect();
-    let base_board = Board::from_str(&puzzle)?;
+    let base_board = Board::parse(&puzzle)?;
 
     let mut best: Option<(Vec<StrategyKind>, Board)> = None;
 

--- a/src/bin/solve.rs
+++ b/src/bin/solve.rs
@@ -1,0 +1,27 @@
+use std::io::{self, Read};
+use sudoku_evaluator::{Solver, board::Board};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let input = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        let mut buf = String::new();
+        io::stdin().read_to_string(&mut buf)?;
+        buf
+    };
+    let puzzle: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    let mut board = Board::parse(&puzzle)?;
+    let solver = Solver::default();
+    match solver.solve(&mut board) {
+        Ok(strategies) => {
+            println!("Solved with strategies: {:?}", strategies);
+            println!("{}", board);
+        }
+        Err(e) => {
+            println!("Failed to solve puzzle: {}", e);
+            println!("{}", board);
+        }
+    }
+    Ok(())
+}

--- a/src/board/candidate.rs
+++ b/src/board/candidate.rs
@@ -65,7 +65,7 @@ impl IntoIterator for CandidateSet {
     }
 }
 
-impl<'a> IntoIterator for &'a CandidateSet {
+impl IntoIterator for &CandidateSet {
     type Item = Digit;
     type IntoIter = CandidateIter;
     fn into_iter(self) -> Self::IntoIter {
@@ -105,8 +105,17 @@ impl CandidatePositions {
     pub fn len(&self) -> usize {
         self.len
     }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
         self.positions[..self.len].iter().copied()
+    }
+}
+
+impl Default for CandidatePositions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -138,8 +147,17 @@ impl CandidateCoords {
     pub fn len(&self) -> usize {
         self.len
     }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
     pub fn iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
         self.coords[..self.len].iter().copied()
+    }
+}
+
+impl Default for CandidateCoords {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -37,13 +37,19 @@ pub fn col_pairs() -> impl Iterator<Item = (usize, usize)> {
     col_indices().flat_map(|c1| col_indices().skip(c1 + 1).map(move |c2| (c1, c2)))
 }
 
-mod board;
+/// Iterator over the starting coordinates of every box.
+pub fn box_indices() -> impl Iterator<Item = (usize, usize)> {
+    (0..BOARD_SIZE / BOX_SIZE)
+        .flat_map(|r| (0..BOARD_SIZE / BOX_SIZE).map(move |c| (r * BOX_SIZE, c * BOX_SIZE)))
+}
+
 mod candidate;
+mod grid;
 mod parser;
 mod unit;
 
-pub use board::Board;
 pub use candidate::*;
+pub use grid::Board;
 pub use parser::BoardError;
 pub use unit::{Unit, UnitIter};
 
@@ -54,14 +60,14 @@ mod tests {
     #[test]
     fn parse_and_display() {
         let puzzle = format!("1{}", ".".repeat(80));
-        let board = Board::from_str(&puzzle).unwrap();
+        let board = Board::parse(&puzzle).unwrap();
         assert_eq!(format!("{}", board), puzzle);
     }
 
     #[test]
     fn candidates_basic() {
         let puzzle = format!("1{}", ".".repeat(80));
-        let mut board = Board::from_str(&puzzle).unwrap();
+        let mut board = Board::parse(&puzzle).unwrap();
         let cands = board.candidates(0, 1);
         assert_eq!(cands, vec![2, 3, 4, 5, 6, 7, 8, 9]);
         board.set(0, 1, 2);

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -1,4 +1,4 @@
-use super::{Digit, board::Board};
+use super::{Digit, grid::Board};
 use std::fmt;
 
 /// Errors that can occur while parsing a puzzle string into a [`Board`].
@@ -24,17 +24,17 @@ impl fmt::Display for BoardError {
 impl std::error::Error for BoardError {}
 
 impl Board {
-    pub fn from_str(puzzle: &str) -> Result<Self, BoardError> {
+    pub fn parse(puzzle: &str) -> Result<Self, BoardError> {
         if puzzle.len() != 81 {
             return Err(BoardError::InvalidLength(puzzle.len()));
         }
-        let mut cells = [[super::board::Cell::new(None); 9]; 9];
+        let mut cells = [[super::grid::Cell::new(None); 9]; 9];
         puzzle.chars().enumerate().try_for_each(|(idx, ch)| {
             let r = idx / 9;
             let c = idx % 9;
             cells[r][c] = match ch {
-                '1'..='9' => super::board::Cell::new(Some(ch.to_digit(10).unwrap() as Digit)),
-                '.' | '0' => super::board::Cell::new(None),
+                '1'..='9' => super::grid::Cell::new(Some(ch.to_digit(10).unwrap() as Digit)),
+                '.' | '0' => super::grid::Cell::new(None),
                 _ => return Err(BoardError::InvalidChar(ch, idx)),
             };
             Ok::<_, BoardError>(())
@@ -52,5 +52,13 @@ impl Board {
 
     pub fn is_solved(&self) -> bool {
         self.cells().all(|(r, c)| self.get(r, c).is_some()) && self.is_valid()
+    }
+}
+
+impl std::str::FromStr for Board {
+    type Err = BoardError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
     }
 }

--- a/src/board/unit.rs
+++ b/src/board/unit.rs
@@ -14,6 +14,22 @@ impl Unit {
             .chain((0..9).map(Unit::Col))
             .chain((0..3).flat_map(|r| (0..3).map(move |c| Unit::Box(r * 3, c * 3))))
     }
+
+    /// Iterator over all box units.
+    pub fn boxes() -> impl Iterator<Item = Unit> {
+        super::box_indices().map(|(r, c)| Unit::Box(r, c))
+    }
+
+    /// Check whether the given coordinate belongs to this unit.
+    pub fn contains(&self, r: usize, c: usize) -> bool {
+        match *self {
+            Unit::Row(row) => row == r,
+            Unit::Col(col) => col == c,
+            Unit::Box(br, bc) => {
+                r >= br && r < br + super::BOX_SIZE && c >= bc && c < bc + super::BOX_SIZE
+            }
+        }
+    }
 }
 
 pub struct UnitIter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,21 +48,8 @@ impl Solver {
         Self { strategies }
     }
 
-    pub fn default() -> Self {
-        Self::new(vec![
-            Box::new(strategy::single_candidate::SingleCandidate),
-            Box::new(strategy::hidden_single::HiddenSingle),
-            Box::new(strategy::naked_pair::NakedPair),
-            Box::new(strategy::naked_triple::NakedTriple),
-            Box::new(strategy::naked_quad::NakedQuad),
-            Box::new(strategy::hidden_pair::HiddenPair),
-            Box::new(strategy::hidden_triple::HiddenTriple),
-            Box::new(strategy::hidden_quad::HiddenQuad),
-            Box::new(strategy::pointing_pair::PointingPair),
-            Box::new(strategy::box_line_reduction::BoxLineReduction),
-            Box::new(strategy::x_wing::XWing),
-            Box::new(strategy::y_wing::YWing),
-        ])
+    pub fn with_default_strategies() -> Self {
+        Self::default()
     }
 
     pub fn solve(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
@@ -91,5 +78,24 @@ impl Solver {
         } else {
             Err(SolverError::Unsolvable)
         }
+    }
+}
+
+impl Default for Solver {
+    fn default() -> Self {
+        Self::new(vec![
+            Box::new(strategy::single_candidate::SingleCandidate),
+            Box::new(strategy::hidden_single::HiddenSingle),
+            Box::new(strategy::naked_pair::NakedPair),
+            Box::new(strategy::naked_triple::NakedTriple),
+            Box::new(strategy::naked_quad::NakedQuad),
+            Box::new(strategy::hidden_pair::HiddenPair),
+            Box::new(strategy::hidden_triple::HiddenTriple),
+            Box::new(strategy::hidden_quad::HiddenQuad),
+            Box::new(strategy::pointing_pair::PointingPair),
+            Box::new(strategy::box_line_reduction::BoxLineReduction),
+            Box::new(strategy::x_wing::XWing),
+            Box::new(strategy::y_wing::YWing),
+        ])
     }
 }

--- a/src/strategy/advanced/x_wing.rs
+++ b/src/strategy/advanced/x_wing.rs
@@ -29,7 +29,6 @@ impl Strategy for XWing {
                                 None => Err(SolverError::Contradiction { row: r, col: c }),
                             }
                         })
-                        .map(|changed| changed)
                 })
             })
             .transpose()?
@@ -55,7 +54,6 @@ impl Strategy for XWing {
                                 None => Err(SolverError::Contradiction { row: r, col: c }),
                             }
                         })
-                        .map(|changed| changed)
                 })
             })
             .transpose()?

--- a/src/strategy/advanced/y_wing.rs
+++ b/src/strategy/advanced/y_wing.rs
@@ -53,7 +53,7 @@ impl Strategy for YWing {
                             cand2
                                 .iter()
                                 .find(|&d| d != d2)
-                                .and_then(|o2| (o2 == other).then(|| (r2, c2)))
+                                .and_then(|o2| (o2 == other).then_some((r2, c2)))
                         })
                         .collect();
 

--- a/src/strategy/basic/box_line_reduction.rs
+++ b/src/strategy/basic/box_line_reduction.rs
@@ -10,57 +10,55 @@ impl Strategy for BoxLineReduction {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for br in 0..3 {
-            for bc in 0..3 {
-                for digit in 1..=9 {
-                    let mut positions = Vec::new();
-                    for r in br * 3..br * 3 + 3 {
-                        for c in bc * 3..bc * 3 + 3 {
-                            if board.get(r, c).is_none() && board.candidates(r, c).contains(digit) {
-                                positions.push((r, c));
-                            }
-                        }
-                    }
-                    if positions.len() <= 1 {
-                        continue;
-                    }
-                    let same_row = positions.iter().all(|&(r, _)| r == positions[0].0);
-                    let same_col = positions.iter().all(|&(_, c)| c == positions[0].1);
-                    if same_row {
-                        let row = positions[0].0;
-                        let mut changed = false;
-                        for c in 0..9 {
-                            if c < bc * 3 || c >= bc * 3 + 3 {
-                                match board.eliminate_candidate(row, c, digit) {
-                                    Some(true) => changed = true,
-                                    None => return Err(SolverError::Contradiction { row, col: c }),
-                                    _ => {}
-                                }
-                            }
-                        }
-                        if changed {
-                            return Ok(true);
-                        }
-                    }
-                    if same_col {
-                        let col = positions[0].1;
-                        let mut changed = false;
-                        for r in 0..9 {
-                            if r < br * 3 || r >= br * 3 + 3 {
-                                match board.eliminate_candidate(r, col, digit) {
-                                    Some(true) => changed = true,
-                                    None => return Err(SolverError::Contradiction { row: r, col }),
-                                    _ => {}
-                                }
-                            }
-                        }
-                        if changed {
-                            return Ok(true);
+        board.try_for_each_box_digit_mut(|b, unit, digit| {
+            let mut positions = Vec::new();
+            b.for_each_in_unit(unit, |r, c, val| {
+                if val.is_none() && b.candidates(r, c).contains(digit) {
+                    positions.push((r, c));
+                }
+            });
+            if positions.len() <= 1 {
+                return Ok(false);
+            }
+
+            let same_row = positions.iter().all(|&(r, _)| r == positions[0].0);
+            let same_col = positions.iter().all(|&(_, c)| c == positions[0].1);
+
+            if same_row {
+                let row = positions[0].0;
+                let mut changed = false;
+                for c in 0..9 {
+                    if !unit.contains(row, c) {
+                        match b.eliminate_candidate(row, c, digit) {
+                            Some(true) => changed = true,
+                            None => return Err(SolverError::Contradiction { row, col: c }),
+                            _ => {}
                         }
                     }
                 }
+                if changed {
+                    return Ok(true);
+                }
             }
-        }
-        Ok(false)
+
+            if same_col {
+                let col = positions[0].1;
+                let mut changed = false;
+                for r in 0..9 {
+                    if !unit.contains(r, col) {
+                        match b.eliminate_candidate(r, col, digit) {
+                            Some(true) => changed = true,
+                            None => return Err(SolverError::Contradiction { row: r, col }),
+                            _ => {}
+                        }
+                    }
+                }
+                if changed {
+                    return Ok(true);
+                }
+            }
+
+            Ok(false)
+        })
     }
 }

--- a/src/strategy/basic/hidden_quad.rs
+++ b/src/strategy/basic/hidden_quad.rs
@@ -125,7 +125,7 @@ where
                     let pos2 = &positions[d2 as usize];
                     let pos3 = &positions[d3 as usize];
                     let pos4 = &positions[d4 as usize];
-                    let mut union: Vec<usize> = pos1.iter().copied().collect();
+                    let mut union = pos1.to_vec();
                     for &p in pos2 {
                         if !union.contains(&p) {
                             union.push(p);

--- a/src/strategy/basic/hidden_single.rs
+++ b/src/strategy/basic/hidden_single.rs
@@ -1,5 +1,5 @@
 use crate::SolverError;
-use crate::board::{Board, Digit};
+use crate::board::{Board, Digit, Unit};
 use crate::strategy::{Strategy, StrategyKind};
 use std::collections::HashMap;
 
@@ -11,85 +11,29 @@ impl Strategy for HiddenSingle {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        // rows
-        for r in 0..9 {
-            if let Some((c, d)) = find_hidden(board, (r, 0..9), Scope::Row)? {
+        for unit in Unit::all() {
+            if let Some((r, c, d)) = find_hidden_unit(board, unit) {
                 board.set(r, c, d);
                 return Ok(true);
-            }
-        }
-        // cols
-        for c in 0..9 {
-            if let Some((r, d)) = find_hidden(board, (c, 0..9), Scope::Col)? {
-                board.set(r, c, d);
-                return Ok(true);
-            }
-        }
-        // boxes
-        for br in 0..3 {
-            for bc in 0..3 {
-                if let Some((r, c, d)) = find_hidden_box(board, br * 3, bc * 3)? {
-                    board.set(r, c, d);
-                    return Ok(true);
-                }
             }
         }
         Ok(false)
     }
 }
 
-enum Scope {
-    Row,
-    Col,
-}
-
-fn find_hidden(
-    board: &Board,
-    index_range: (usize, std::ops::Range<usize>),
-    scope: Scope,
-) -> Result<Option<(usize, Digit)>, SolverError> {
-    let (fixed, range) = index_range;
-    let mut locs: HashMap<Digit, Vec<usize>> = HashMap::new();
-    for var in range.clone() {
-        let (r, c) = match scope {
-            Scope::Row => (fixed, var),
-            Scope::Col => (var, fixed),
-        };
-        if board.get(r, c).is_none() {
-            for d in board.candidates(r, c) {
-                locs.entry(d).or_default().push(var);
-            }
-        }
-    }
-    for (d, positions) in locs {
-        if positions.len() == 1 {
-            let var = positions[0];
-            return Ok(Some((var, d)));
-        }
-    }
-    Ok(None)
-}
-
-fn find_hidden_box(
-    board: &Board,
-    start_r: usize,
-    start_c: usize,
-) -> Result<Option<(usize, usize, Digit)>, SolverError> {
+fn find_hidden_unit(board: &Board, unit: Unit) -> Option<(usize, usize, Digit)> {
     let mut locs: HashMap<Digit, Vec<(usize, usize)>> = HashMap::new();
-    for r in start_r..start_r + 3 {
-        for c in start_c..start_c + 3 {
-            if board.get(r, c).is_none() {
-                for d in board.candidates(r, c) {
-                    locs.entry(d).or_default().push((r, c));
-                }
+    board.for_each_in_unit(unit, |r, c, val| {
+        if val.is_none() {
+            for d in board.candidates(r, c) {
+                locs.entry(d).or_default().push((r, c));
             }
         }
-    }
-    for (d, positions) in locs {
-        if positions.len() == 1 {
-            let (r, c) = positions[0];
-            return Ok(Some((r, c, d)));
-        }
-    }
-    Ok(None)
+    });
+    locs.into_iter().find_map(|(d, pos)| {
+        (pos.len() == 1).then(|| {
+            let (r, c) = pos[0];
+            (r, c, d)
+        })
+    })
 }

--- a/src/strategy/basic/hidden_triple.rs
+++ b/src/strategy/basic/hidden_triple.rs
@@ -44,9 +44,9 @@ fn search_unit(board: &mut Board, unit: Unit) -> Result<bool, SolverError> {
                     }
                 }
                 if union.len() == 3
-                    && positions[d1 as usize].len() >= 1
-                    && positions[d2 as usize].len() >= 1
-                    && positions[d3 as usize].len() >= 1
+                    && !positions[d1 as usize].is_empty()
+                    && !positions[d2 as usize].is_empty()
+                    && !positions[d3 as usize].is_empty()
                 {
                     let mut changed = false;
                     for &(r, c) in &union {

--- a/src/strategy/basic/naked_pair.rs
+++ b/src/strategy/basic/naked_pair.rs
@@ -33,16 +33,17 @@ fn search_unit(board: &mut Board, unit: Unit) -> Result<bool, SolverError> {
                 let digits = cells[i].1;
                 let mut changed = false;
                 for (rr, cc) in board.unit_iter(unit) {
-                    if (rr, cc) != cells[i].0 && (rr, cc) != cells[j].0 {
-                        if board.get(rr, cc).is_none() {
-                            for d in &digits {
-                                match board.eliminate_candidate(rr, cc, d) {
-                                    Some(true) => changed = true,
-                                    None => {
-                                        return Err(SolverError::Contradiction { row: rr, col: cc });
-                                    }
-                                    _ => {}
+                    if (rr, cc) != cells[i].0
+                        && (rr, cc) != cells[j].0
+                        && board.get(rr, cc).is_none()
+                    {
+                        for d in &digits {
+                            match board.eliminate_candidate(rr, cc, d) {
+                                Some(true) => changed = true,
+                                None => {
+                                    return Err(SolverError::Contradiction { row: rr, col: cc });
                                 }
+                                _ => {}
                             }
                         }
                     }

--- a/src/strategy/basic/pointing_pair.rs
+++ b/src/strategy/basic/pointing_pair.rs
@@ -10,60 +10,50 @@ impl Strategy for PointingPair {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for br in 0..3 {
-            for bc in 0..3 {
-                for digit in 1..=9 {
-                    let mut positions = Vec::new();
-                    for r in br * 3..br * 3 + 3 {
-                        for c in bc * 3..bc * 3 + 3 {
-                            if board.get(r, c).is_none() && board.candidates(r, c).contains(digit) {
-                                positions.push((r, c));
+        board.try_for_each_box_digit_mut(|b, unit, digit| {
+            let mut positions = Vec::new();
+            b.for_each_in_unit(unit, |r, c, val| {
+                if val.is_none() && b.candidates(r, c).contains(digit) {
+                    positions.push((r, c));
+                }
+            });
+            if positions.len() == 2 {
+                let same_row = positions[0].0 == positions[1].0;
+                let same_col = positions[0].1 == positions[1].1;
+                if same_row {
+                    let row = positions[0].0;
+                    let mut changed = false;
+                    for c in 0..9 {
+                        if !unit.contains(row, c) {
+                            match b.eliminate_candidate(row, c, digit) {
+                                Some(true) => changed = true,
+                                None => return Err(SolverError::Contradiction { row, col: c }),
+                                _ => {}
                             }
                         }
                     }
-                    if positions.len() == 2 {
-                        let same_row = positions[0].0 == positions[1].0;
-                        let same_col = positions[0].1 == positions[1].1;
-                        if same_row {
-                            let row = positions[0].0;
-                            let mut changed = false;
-                            for c in 0..9 {
-                                if c < bc * 3 || c >= bc * 3 + 3 {
-                                    match board.eliminate_candidate(row, c, digit) {
-                                        Some(true) => changed = true,
-                                        None => {
-                                            return Err(SolverError::Contradiction { row, col: c });
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-                            if changed {
-                                return Ok(true);
+                    if changed {
+                        return Ok(true);
+                    }
+                }
+                if same_col {
+                    let col = positions[0].1;
+                    let mut changed = false;
+                    for r in 0..9 {
+                        if !unit.contains(r, col) {
+                            match b.eliminate_candidate(r, col, digit) {
+                                Some(true) => changed = true,
+                                None => return Err(SolverError::Contradiction { row: r, col }),
+                                _ => {}
                             }
                         }
-                        if same_col {
-                            let col = positions[0].1;
-                            let mut changed = false;
-                            for r in 0..9 {
-                                if r < br * 3 || r >= br * 3 + 3 {
-                                    match board.eliminate_candidate(r, col, digit) {
-                                        Some(true) => changed = true,
-                                        None => {
-                                            return Err(SolverError::Contradiction { row: r, col });
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-                            if changed {
-                                return Ok(true);
-                            }
-                        }
+                    }
+                    if changed {
+                        return Ok(true);
                     }
                 }
             }
-        }
-        Ok(false)
+            Ok(false)
+        })
     }
 }

--- a/src/strategy/basic/single_candidate.rs
+++ b/src/strategy/basic/single_candidate.rs
@@ -1,5 +1,5 @@
 use crate::SolverError;
-use crate::board::Board;
+use crate::board::{Board, Digit};
 use crate::strategy::{Strategy, StrategyKind};
 
 pub struct SingleCandidate;
@@ -10,16 +10,22 @@ impl Strategy for SingleCandidate {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for r in 0..9 {
-            for c in 0..9 {
-                let cand = board.candidates(r, c);
-                if cand.len() == 1 {
-                    let digit = cand.into_iter().next().unwrap();
-                    board.set(r, c, digit);
-                    return Ok(true);
-                }
+        let mut res: Option<(usize, usize, Digit)> = None;
+        board.try_for_each_cell_mut(|b, r, c| {
+            let cand = b.candidates(r, c);
+            if cand.len() == 1 {
+                let digit = cand.into_iter().next().unwrap();
+                res = Some((r, c, digit));
+                Ok(true)
+            } else {
+                Ok(false)
             }
+        })?;
+        if let Some((r, c, d)) = res {
+            board.set(r, c, d);
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(false)
     }
 }

--- a/tests/board_iteration.rs
+++ b/tests/board_iteration.rs
@@ -1,0 +1,71 @@
+use sudoku_evaluator::board::Board;
+use sudoku_evaluator::board::Unit;
+
+#[test]
+fn for_each_visits_all_cells() {
+    let board = Board::parse(&".".repeat(81)).unwrap();
+    let mut count = 0;
+    board.for_each_cell(|_, _, _| count += 1);
+    assert_eq!(count, 81);
+}
+
+#[test]
+fn try_for_each_stops_on_true() {
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
+    let mut visited = 0;
+    let res = board.try_for_each_cell_mut::<_, ()>(|_, _, _| {
+        visited += 1;
+        Ok(visited == 5)
+    });
+    assert!(res.unwrap());
+    assert_eq!(visited, 5);
+}
+
+#[test]
+fn try_for_each_cell_non_mut() {
+    let board = Board::parse(&".".repeat(81)).unwrap();
+    let mut visited = 0;
+    let res = board.try_for_each_cell::<_, ()>(|_, _, _| {
+        visited += 1;
+        Ok(visited == 7)
+    });
+    assert!(res.unwrap());
+    assert_eq!(visited, 7);
+}
+
+#[test]
+fn for_each_cell_mut_counts() {
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
+    let mut count = 0;
+    board.for_each_cell_mut(|_, _, _| count += 1);
+    assert_eq!(count, 81);
+}
+
+#[test]
+fn unit_iteration_helpers() {
+    let board = Board::parse(&".".repeat(81)).unwrap();
+    let mut count = 0;
+    board.for_each_in_unit(Unit::Row(0), |_, _, _| count += 1);
+    assert_eq!(count, 9);
+
+    let mut visited = 0;
+    let mut board2 = board.clone();
+    let res = board2.try_for_each_in_unit_mut::<_, ()>(Unit::Row(0), |_, _, _| {
+        visited += 1;
+        Ok(visited == 4)
+    });
+    assert!(res.unwrap());
+    assert_eq!(visited, 4);
+}
+
+#[test]
+fn box_iteration_helpers() {
+    let board = Board::parse(&".".repeat(81)).unwrap();
+    let mut count = 0;
+    board.for_each_box(|_| count += 1);
+    assert_eq!(count, 9);
+
+    let mut combos = 0;
+    board.for_each_box_digit(|_, _| combos += 1);
+    assert_eq!(combos, 81);
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+#[test]
+fn solve_cli_succeeds() {
+    let puzzle =
+        "530070000600195000098000060800060003400803001700020006060000280000419005000080079";
+    let output = Command::new(env!("CARGO_BIN_EXE_solve"))
+        .arg(puzzle)
+        .output()
+        .expect("failed to run solve binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Solved with strategies"));
+}

--- a/tests/solver_tests.rs
+++ b/tests/solver_tests.rs
@@ -8,7 +8,7 @@ use sudoku_evaluator::{
 fn already_solved() {
     let puzzle =
         "534678912672195348198342567859761423426853791713924856961537284287419635345286179";
-    let mut board = Board::from_str(puzzle).unwrap();
+    let mut board = Board::parse(puzzle).unwrap();
     let solver = Solver::default();
     let used = solver.solve(&mut board).unwrap();
     assert!(used.is_empty());
@@ -18,7 +18,7 @@ fn already_solved() {
 fn single_candidate_only() {
     let puzzle =
         "53467891267219534819834256785976142342685379171392485696153728428741963534528617.";
-    let mut board = Board::from_str(puzzle).unwrap();
+    let mut board = Board::parse(puzzle).unwrap();
     let solver = Solver::default();
     let used = solver.solve(&mut board).unwrap();
     assert_eq!(used, vec![StrategyKind::SingleCandidate]);
@@ -28,7 +28,7 @@ fn single_candidate_only() {
 #[test]
 fn invalid_board() {
     let puzzle = format!("11{}", ".".repeat(79)); // duplicate 1 in row
-    let mut board = Board::from_str(&puzzle).unwrap();
+    let mut board = Board::parse(&puzzle).unwrap();
     let solver = Solver::default();
     let err = solver.solve(&mut board).unwrap_err();
     assert!(matches!(err, sudoku_evaluator::SolverError::InvalidBoard));
@@ -38,7 +38,7 @@ fn invalid_board() {
 fn solve_easy_puzzle() {
     let puzzle =
         "530070000600195000098000060800060003400803001700020006060000280000419005000080079";
-    let mut board = Board::from_str(puzzle).unwrap();
+    let mut board = Board::parse(puzzle).unwrap();
     let solver = Solver::default();
     let used = solver.solve(&mut board).unwrap();
     assert!(board.is_solved());
@@ -49,7 +49,7 @@ fn solve_easy_puzzle() {
 fn solve_harder_puzzle() {
     let puzzle =
         "003020600900305001001806400008102900700000008006708200002609500800203009005010300";
-    let mut board = Board::from_str(puzzle).unwrap();
+    let mut board = Board::parse(puzzle).unwrap();
     let solver = Solver::default();
     let used = solver.solve(&mut board).unwrap();
     assert!(board.is_solved());
@@ -58,7 +58,7 @@ fn solve_harder_puzzle() {
 
 #[test]
 fn naked_pair_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     // setup row 0 naked pair in c0 and c1, candidate {1,2}
     for d in 3..=9 {
         board.eliminate_candidate(0, 0, d);
@@ -75,7 +75,7 @@ fn naked_pair_strategy() {
 
 #[test]
 fn box_line_reduction_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     // in box (0,0), digit 1 only appears in row 0
     for d in 3..=9 {
         board.eliminate_candidate(0, 0, d);
@@ -102,7 +102,7 @@ fn box_line_reduction_strategy() {
 fn solve_very_hard_puzzle() {
     let puzzle =
         "..467.....7..9...8.9..4.5.7.5...1.234.6..37...........9...372.4.8.4.9.3...5.8...9";
-    let mut board = Board::from_str(puzzle).unwrap();
+    let mut board = Board::parse(puzzle).unwrap();
     let solver = Solver::default();
     let used = solver.solve(&mut board).unwrap();
     assert!(board.is_solved());
@@ -111,7 +111,7 @@ fn solve_very_hard_puzzle() {
 
 #[test]
 fn x_wing_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     for r in 0..2 {
         for c in 0..9 {
             if c != 0 && c != 2 {
@@ -129,7 +129,7 @@ fn x_wing_strategy() {
 
 #[test]
 fn y_wing_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     for d in 1..=9 {
         if d != 1 && d != 2 {
             board.eliminate_candidate(0, 0, d);
@@ -151,7 +151,7 @@ fn y_wing_strategy() {
 
 #[test]
 fn hidden_pair_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     for c in 0..9 {
         for d in 1..=9 {
             if c == 0 || c == 1 {
@@ -176,7 +176,7 @@ fn hidden_pair_strategy() {
 
 #[test]
 fn naked_triple_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     for c in 0..3 {
         for d in 4..=9 {
             board.eliminate_candidate(0, c, d);
@@ -192,7 +192,7 @@ fn naked_triple_strategy() {
 
 #[test]
 fn hidden_triple_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     for c in 3..9 {
         board.eliminate_candidate(0, c, 1);
         board.eliminate_candidate(0, c, 2);
@@ -220,7 +220,7 @@ fn hidden_triple_strategy() {
 
 #[test]
 fn pointing_pair_strategy() {
-    let mut board = Board::from_str(&".".repeat(81)).unwrap();
+    let mut board = Board::parse(&".".repeat(81)).unwrap();
     // digit 1 only in cells (0,0) and (0,1) of box 0
     for r in 0..3 {
         for c in 0..3 {


### PR DESCRIPTION
## Summary
- add simple `solve` binary for solving puzzles from CLI
- provide integration test for the new CLI
- document the CLI in the README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68749db3319483249ba4cf590c7b223b