### PR TITLE
Improve ProgressiveSolver strategy detection

### DIFF
--- a/src/bin/evaluator.rs
+++ b/src/bin/evaluator.rs
@@ -1,80 +1,6 @@
 use std::env;
 use std::io::{self, Read};
-use sudoku_evaluator::{
-    Solver,
-    board::Board,
-    strategy::{Strategy, StrategyKind},
-};
-
-fn kind_to_strategy(kind: StrategyKind) -> Box<dyn Strategy> {
-    match kind {
-        StrategyKind::SingleCandidate => {
-            Box::new(sudoku_evaluator::strategy::single_candidate::SingleCandidate)
-        }
-        StrategyKind::HiddenSingle => {
-            Box::new(sudoku_evaluator::strategy::hidden_single::HiddenSingle)
-        }
-        StrategyKind::NakedPair => Box::new(sudoku_evaluator::strategy::naked_pair::NakedPair),
-        StrategyKind::NakedTriple => {
-            Box::new(sudoku_evaluator::strategy::naked_triple::NakedTriple)
-        }
-        StrategyKind::NakedQuad => Box::new(sudoku_evaluator::strategy::naked_quad::NakedQuad),
-        StrategyKind::HiddenPair => Box::new(sudoku_evaluator::strategy::hidden_pair::HiddenPair),
-        StrategyKind::HiddenTriple => {
-            Box::new(sudoku_evaluator::strategy::hidden_triple::HiddenTriple)
-        }
-        StrategyKind::HiddenQuad => Box::new(sudoku_evaluator::strategy::hidden_quad::HiddenQuad),
-        StrategyKind::PointingPair => {
-            Box::new(sudoku_evaluator::strategy::pointing_pair::PointingPair)
-        }
-        StrategyKind::BoxLineReduction => {
-            Box::new(sudoku_evaluator::strategy::box_line_reduction::BoxLineReduction)
-        }
-        StrategyKind::XWing => Box::new(sudoku_evaluator::strategy::x_wing::XWing),
-        StrategyKind::YWing => Box::new(sudoku_evaluator::strategy::y_wing::YWing),
-        StrategyKind::Swordfish => Box::new(sudoku_evaluator::strategy::swordfish::Swordfish),
-        StrategyKind::Jellyfish => Box::new(sudoku_evaluator::strategy::jellyfish::Jellyfish),
-        StrategyKind::UniqueRectangle => {
-            Box::new(sudoku_evaluator::strategy::unique_rectangle::UniqueRectangle)
-        }
-        StrategyKind::XYZWing => Box::new(sudoku_evaluator::strategy::xyz_wing::XYZWing),
-        StrategyKind::XYChain => Box::new(sudoku_evaluator::strategy::xy_chain::XYChain),
-        StrategyKind::XYWing => Box::new(sudoku_evaluator::strategy::xy_wing::XYWing),
-        StrategyKind::SimpleColoring => {
-            Box::new(sudoku_evaluator::strategy::simple_coloring::SimpleColoring)
-        }
-        StrategyKind::Bug => Box::new(sudoku_evaluator::strategy::bug::Bug),
-        StrategyKind::ForcingChain => {
-            Box::new(sudoku_evaluator::strategy::forcing_chain::ForcingChain)
-        }
-        StrategyKind::Nishio => Box::new(sudoku_evaluator::strategy::nishio::Nishio),
-    }
-}
-
-const ALL_KINDS: [StrategyKind; 22] = [
-    StrategyKind::SingleCandidate,
-    StrategyKind::HiddenSingle,
-    StrategyKind::NakedPair,
-    StrategyKind::NakedTriple,
-    StrategyKind::NakedQuad,
-    StrategyKind::HiddenPair,
-    StrategyKind::HiddenTriple,
-    StrategyKind::HiddenQuad,
-    StrategyKind::PointingPair,
-    StrategyKind::BoxLineReduction,
-    StrategyKind::XWing,
-    StrategyKind::YWing,
-    StrategyKind::Swordfish,
-    StrategyKind::Jellyfish,
-    StrategyKind::UniqueRectangle,
-    StrategyKind::XYZWing,
-    StrategyKind::XYChain,
-    StrategyKind::XYWing,
-    StrategyKind::SimpleColoring,
-    StrategyKind::Bug,
-    StrategyKind::ForcingChain,
-    StrategyKind::Nishio,
-];
+use sudoku_evaluator::{ProgressiveSolver, board::Board};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
@@ -86,37 +12,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         buf
     };
     let puzzle: String = input.chars().filter(|c| !c.is_whitespace()).collect();
-    let base_board = Board::parse(&puzzle)?;
-
-    let mut best: Option<(Vec<StrategyKind>, Board)> = None;
-
-    for mask in 1usize..(1 << ALL_KINDS.len()) {
-        let kinds: Vec<StrategyKind> = ALL_KINDS
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| mask & (1 << i) != 0)
-            .map(|(_, &k)| k)
-            .collect();
-        if let Some((ref best_kinds, _)) = best {
-            if kinds.len() >= best_kinds.len() {
-                continue;
-            }
+    let mut board = Board::parse(&puzzle)?;
+    let solver = ProgressiveSolver::default();
+    match solver.solve(&mut board) {
+        Ok(kinds) => {
+            println!("Solved with strategies: {:?}", kinds);
+            println!("{}", board);
         }
-        let strategies: Vec<Box<dyn Strategy>> =
-            kinds.iter().map(|&k| kind_to_strategy(k)).collect();
-        let solver = Solver::new(strategies);
-        let mut board = base_board.clone();
-        if solver.solve(&mut board).is_ok() {
-            best = Some((kinds, board));
+        Err(e) => {
+            println!("Failed to solve puzzle: {}", e);
+            println!("{}", board);
         }
     }
-
-    if let Some((kinds, board)) = best {
-        println!("Solved with strategies: {:?}", kinds);
-        println!("{}", board);
-    } else {
-        println!("Puzzle could not be solved with available strategies");
-    }
-
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 
 pub mod board;
 pub use board::BoardError;
+pub mod progressive;
 pub mod strategy;
+pub use progressive::ProgressiveSolver;
 
 use board::Board;
 use std::error::Error;
@@ -102,7 +104,7 @@ impl Solver {
         ])
     }
 
-    pub fn solve(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
+    fn apply_strategies(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
         if !board.is_valid() {
             return Err(SolverError::InvalidBoard);
         }
@@ -123,11 +125,22 @@ impl Solver {
                 break;
             }
         }
+        Ok(used)
+    }
+
+    /// Attempt to fully solve the board.
+    pub fn solve(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
+        let used = self.apply_strategies(board)?;
         if board.is_solved() {
             Ok(used)
         } else {
             Err(SolverError::Unsolvable)
         }
+    }
+
+    /// Apply strategies until no further progress can be made.
+    pub fn reduce(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
+        self.apply_strategies(board)
     }
 }
 

--- a/src/progressive.rs
+++ b/src/progressive.rs
@@ -1,0 +1,55 @@
+use crate::board::Board;
+use crate::strategy::{self, StrategyKind};
+use crate::{Solver, SolverError};
+
+/// Solver that progressively enables more advanced strategies.
+pub struct ProgressiveSolver {
+    basic: Vec<StrategyKind>,
+}
+
+impl Default for ProgressiveSolver {
+    fn default() -> Self {
+        Self {
+            basic: vec![StrategyKind::SingleCandidate, StrategyKind::HiddenSingle],
+        }
+    }
+}
+
+impl ProgressiveSolver {
+    /// Solve the puzzle by enabling strategies one by one.
+    pub fn solve(&self, board: &mut Board) -> Result<Vec<StrategyKind>, SolverError> {
+        let mut kinds = self.basic.clone();
+        loop {
+            Solver::new(strategies_from(&kinds)).reduce(board)?;
+            if board.is_solved() {
+                return Ok(kinds);
+            }
+            let snapshot = board.clone();
+            let mut next = None;
+            for &kind in &strategy::ALL_KINDS {
+                if kinds.contains(&kind) {
+                    continue;
+                }
+                let mut trial_board = snapshot.clone();
+                let mut trial_kinds = kinds.clone();
+                trial_kinds.push(kind);
+                Solver::new(strategies_from(&trial_kinds)).reduce(&mut trial_board)?;
+                if trial_board != snapshot {
+                    next = Some(kind);
+                    break;
+                }
+            }
+            match next {
+                Some(k) => kinds.push(k),
+                None => return Err(SolverError::Unsolvable),
+            }
+        }
+    }
+}
+
+fn strategies_from(kinds: &[StrategyKind]) -> Vec<Box<dyn strategy::Strategy>> {
+    kinds
+        .iter()
+        .map(|&k| strategy::kind_to_strategy(k))
+        .collect()
+}

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -62,3 +62,57 @@ pub trait Strategy {
     fn kind(&self) -> StrategyKind;
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError>;
 }
+
+/// All strategies in order from simplest to most advanced.
+pub const ALL_KINDS: [StrategyKind; 22] = [
+    StrategyKind::SingleCandidate,
+    StrategyKind::HiddenSingle,
+    StrategyKind::NakedPair,
+    StrategyKind::NakedTriple,
+    StrategyKind::NakedQuad,
+    StrategyKind::HiddenPair,
+    StrategyKind::HiddenTriple,
+    StrategyKind::HiddenQuad,
+    StrategyKind::PointingPair,
+    StrategyKind::BoxLineReduction,
+    StrategyKind::XWing,
+    StrategyKind::YWing,
+    StrategyKind::Swordfish,
+    StrategyKind::Jellyfish,
+    StrategyKind::UniqueRectangle,
+    StrategyKind::XYZWing,
+    StrategyKind::XYChain,
+    StrategyKind::XYWing,
+    StrategyKind::SimpleColoring,
+    StrategyKind::Bug,
+    StrategyKind::ForcingChain,
+    StrategyKind::Nishio,
+];
+
+/// Create a boxed strategy instance for the given kind.
+pub fn kind_to_strategy(kind: StrategyKind) -> Box<dyn Strategy> {
+    match kind {
+        StrategyKind::SingleCandidate => Box::new(single_candidate::SingleCandidate),
+        StrategyKind::HiddenSingle => Box::new(hidden_single::HiddenSingle),
+        StrategyKind::NakedPair => Box::new(naked_pair::NakedPair),
+        StrategyKind::NakedTriple => Box::new(naked_triple::NakedTriple),
+        StrategyKind::NakedQuad => Box::new(naked_quad::NakedQuad),
+        StrategyKind::HiddenPair => Box::new(hidden_pair::HiddenPair),
+        StrategyKind::HiddenTriple => Box::new(hidden_triple::HiddenTriple),
+        StrategyKind::HiddenQuad => Box::new(hidden_quad::HiddenQuad),
+        StrategyKind::PointingPair => Box::new(pointing_pair::PointingPair),
+        StrategyKind::BoxLineReduction => Box::new(box_line_reduction::BoxLineReduction),
+        StrategyKind::XWing => Box::new(x_wing::XWing),
+        StrategyKind::YWing => Box::new(y_wing::YWing),
+        StrategyKind::Swordfish => Box::new(swordfish::Swordfish),
+        StrategyKind::Jellyfish => Box::new(jellyfish::Jellyfish),
+        StrategyKind::UniqueRectangle => Box::new(unique_rectangle::UniqueRectangle),
+        StrategyKind::XYZWing => Box::new(xyz_wing::XYZWing),
+        StrategyKind::XYChain => Box::new(xy_chain::XYChain),
+        StrategyKind::XYWing => Box::new(xy_wing::XYWing),
+        StrategyKind::SimpleColoring => Box::new(simple_coloring::SimpleColoring),
+        StrategyKind::Bug => Box::new(bug::Bug),
+        StrategyKind::ForcingChain => Box::new(forcing_chain::ForcingChain),
+        StrategyKind::Nishio => Box::new(nishio::Nishio),
+    }
+}

--- a/src/strategy/advanced/simple_coloring.rs
+++ b/src/strategy/advanced/simple_coloring.rs
@@ -59,8 +59,10 @@ impl Strategy for SimpleColoring {
                     let color = *component.get(&(cr, cc)).unwrap();
                     if let Some(neigh) = adjacency.get(&(cr, cc)) {
                         for &(nr, nc) in neigh {
-                            if !component.contains_key(&(nr, nc)) {
-                                component.insert((nr, nc), !color);
+                            if let std::collections::hash_map::Entry::Vacant(e) =
+                                component.entry((nr, nc))
+                            {
+                                e.insert(!color);
                                 visited.insert((nr, nc));
                                 queue.push_back((nr, nc));
                             }
@@ -92,9 +94,8 @@ impl Strategy for SimpleColoring {
                     if invalid[color as usize] {
                         for &(cr, cc) in &color_sets[color as usize] {
                             if let Some(res) = board.eliminate_candidate(cr, cc, digit) {
-                                match res {
-                                    true => changed = true,
-                                    false => (),
+                                if res {
+                                    changed = true;
                                 }
                             } else {
                                 return Err(SolverError::Contradiction { row: cr, col: cc });

--- a/src/strategy/advanced/unique_rectangle.rs
+++ b/src/strategy/advanced/unique_rectangle.rs
@@ -46,9 +46,8 @@ impl Strategy for UniqueRectangle {
                                 for d in cands.iter() {
                                     if d != a && d != b {
                                         if let Some(res) = board.eliminate_candidate(er, ec, d) {
-                                            match res {
-                                                true => changed = true,
-                                                false => {}
+                                            if res {
+                                                changed = true;
                                             }
                                         } else {
                                             return Err(SolverError::Contradiction {

--- a/tests/progressive_solver.rs
+++ b/tests/progressive_solver.rs
@@ -1,0 +1,25 @@
+use sudoku_evaluator::{ProgressiveSolver, SolverError, board::Board, strategy::StrategyKind};
+
+#[test]
+fn progressive_solver_solves_puzzle() {
+    let puzzle =
+        "530070000600195000098000060800060003400803001700020006060000280000419005000080079";
+    let mut board = Board::parse(puzzle).unwrap();
+    let solver = ProgressiveSolver::default();
+    let kinds = solver.solve(&mut board).unwrap();
+    assert!(board.is_solved());
+    assert_eq!(
+        kinds,
+        vec![StrategyKind::SingleCandidate, StrategyKind::HiddenSingle]
+    );
+}
+
+#[test]
+fn progressive_solver_unsolvable() {
+    let puzzle =
+        "000982000035100870800300059090015000002000600000620040900201003013006520000700000";
+    let mut board = Board::parse(puzzle).unwrap();
+    let solver = ProgressiveSolver::default();
+    let err = solver.solve(&mut board).unwrap_err();
+    assert!(matches!(err, SolverError::Unsolvable));
+}


### PR DESCRIPTION
## Summary
- enhance progressive strategy discovery to run full reductions when testing a new strategy
- validate the exact strategy list for an easy puzzle

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68750a6d1d2c8324ae3d1728d86fdc77