### PR TITLE
Add unsolved cell iteration helpers

### DIFF
--- a/src/board/grid.rs
+++ b/src/board/grid.rs
@@ -126,6 +126,11 @@ impl Board {
         (0..9).flat_map(|r| (0..9).map(move |c| (r, c)))
     }
 
+    /// Iterate over every unsolved cell on the board.
+    pub fn unsolved_cells(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.cells().filter(|&(r, c)| self.get(r, c).is_none())
+    }
+
     /// Iterate over every cell on the board in row-major order.
     ///
     /// The provided closure receives the row, column and current value

--- a/src/strategy/advanced/bug.rs
+++ b/src/strategy/advanced/bug.rs
@@ -11,20 +11,16 @@ impl Strategy for Bug {
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
         let mut multi_cell = None;
-        for r in board::row_indices() {
-            for c in board::col_indices() {
-                if board.get(r, c).is_none() {
-                    let count = board.candidates(r, c).len();
-                    if count > 2 {
-                        if multi_cell.is_none() {
-                            multi_cell = Some((r, c));
-                        } else {
-                            return Ok(false);
-                        }
-                    } else if count < 2 {
-                        return Ok(false);
-                    }
+        for (r, c) in board.unsolved_cells() {
+            let count = board.candidates(r, c).len();
+            if count > 2 {
+                if multi_cell.is_none() {
+                    multi_cell = Some((r, c));
+                } else {
+                    return Ok(false);
                 }
+            } else if count < 2 {
+                return Ok(false);
             }
         }
 
@@ -34,13 +30,9 @@ impl Strategy for Bug {
         };
 
         let mut digit_counts = [0usize; 10];
-        for r0 in board::row_indices() {
-            for c0 in board::col_indices() {
-                if board.get(r0, c0).is_none() {
-                    for d in board.candidates(r0, c0) {
-                        digit_counts[d as usize] += 1;
-                    }
-                }
+        for (r0, c0) in board.unsolved_cells() {
+            for d in board.candidates(r0, c0) {
+                digit_counts[d as usize] += 1;
             }
         }
 

--- a/src/strategy/advanced/forcing_chain.rs
+++ b/src/strategy/advanced/forcing_chain.rs
@@ -12,23 +12,15 @@ impl Strategy for ForcingChain {
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
         let mut target = None;
         let mut best_len = 10;
-        for r in board::row_indices() {
-            for c in board::col_indices() {
-                if board.get(r, c).is_some() {
-                    continue;
+        for (r, c) in board.unsolved_cells() {
+            let cands = board.candidates(r, c);
+            let len = cands.len();
+            if len > 1 && len < best_len {
+                best_len = len;
+                target = Some((r, c, cands));
+                if len == 2 {
+                    break;
                 }
-                let cands = board.candidates(r, c);
-                let len = cands.len();
-                if len > 1 && len < best_len {
-                    best_len = len;
-                    target = Some((r, c, cands));
-                    if len == 2 {
-                        break;
-                    }
-                }
-            }
-            if best_len == 2 {
-                break;
             }
         }
 

--- a/src/strategy/advanced/nishio.rs
+++ b/src/strategy/advanced/nishio.rs
@@ -10,25 +10,21 @@ impl Strategy for Nishio {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for r in board::row_indices() {
-            for c in board::col_indices() {
-                if board.get(r, c).is_some() {
-                    continue;
-                }
-                let cands = board.candidates(r, c);
-                if cands.len() <= 1 || cands.len() > 4 {
-                    continue;
-                }
-                for d in cands.iter() {
-                    let mut trial = board.clone();
-                    trial.set(r, c, d);
-                    let solver = Solver::without_nishio_and_forcing_chain();
-                    if solver.solve(&mut trial).is_err() {
-                        match board.eliminate_candidate(r, c, d) {
-                            Some(true) => return Ok(true),
-                            Some(false) => {}
-                            None => return Err(SolverError::Contradiction { row: r, col: c }),
-                        }
+        let cells: Vec<_> = board.unsolved_cells().collect();
+        for (r, c) in cells {
+            let cands = board.candidates(r, c);
+            if cands.len() <= 1 || cands.len() > 4 {
+                continue;
+            }
+            for d in cands.iter() {
+                let mut trial = board.clone();
+                trial.set(r, c, d);
+                let solver = Solver::without_nishio_and_forcing_chain();
+                if solver.solve(&mut trial).is_err() {
+                    match board.eliminate_candidate(r, c, d) {
+                        Some(true) => return Ok(true),
+                        Some(false) => {}
+                        None => return Err(SolverError::Contradiction { row: r, col: c }),
                     }
                 }
             }

--- a/src/strategy/advanced/xy_chain.rs
+++ b/src/strategy/advanced/xy_chain.rs
@@ -21,72 +21,73 @@ impl Strategy for XYChain {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for r0 in crate::board::row_indices() {
-            for c0 in crate::board::col_indices() {
-                let pivot = board.candidates(r0, c0);
-                if pivot.len() != PAIR_LEN {
-                    continue;
-                }
-                let digits: Vec<u8> = pivot.iter().collect();
-                let peers0 = board.peer_coords(r0, c0);
+        let cells: Vec<_> = board.unsolved_cells().collect();
+        for (r0, c0) in cells {
+            let pivot = board.candidates(r0, c0);
+            if pivot.len() != PAIR_LEN {
+                continue;
+            }
 
-                for &start_digit in &digits {
-                    let other_digit = digits.iter().find(|&&d| d != start_digit).copied().unwrap();
-                    let start = Node {
-                        r: r0,
-                        c: c0,
-                        digit: start_digit,
-                        prev: other_digit,
-                    };
-                    let mut queue = VecDeque::new();
-                    queue.push_back(start);
-                    let mut visited: HashSet<(usize, usize, u8)> = HashSet::new();
-                    visited.insert((start.r, start.c, start.digit));
+            let digits: Vec<u8> = pivot.iter().collect();
+            let peers0 = board.peer_coords(r0, c0);
 
-                    while let Some(node) = queue.pop_front() {
-                        let peers = board.peer_coords(node.r, node.c);
-                        for &(nr, nc) in &peers {
-                            let cand = board.candidates(nr, nc);
-                            if cand.len() != PAIR_LEN || !cand.contains(node.digit) {
-                                continue;
+            for &start_digit in &digits {
+                let other_digit = digits.iter().find(|&&d| d != start_digit).copied().unwrap();
+                let start = Node {
+                    r: r0,
+                    c: c0,
+                    digit: start_digit,
+                    prev: other_digit,
+                };
+                let mut queue = VecDeque::new();
+                queue.push_back(start);
+                let mut visited: HashSet<(usize, usize, u8)> = HashSet::new();
+                visited.insert((start.r, start.c, start.digit));
+
+                while let Some(node) = queue.pop_front() {
+                    let peers = board.peer_coords(node.r, node.c);
+                    for &(nr, nc) in &peers {
+                        let cand = board.candidates(nr, nc);
+                        if cand.len() != PAIR_LEN || !cand.contains(node.digit) {
+                            continue;
+                        }
+                        let next_digit = cand.iter().find(|&d| d != node.digit).unwrap();
+
+                        if (nr, nc) != (r0, c0)
+                            && next_digit == start_digit
+                            && peers0.contains(&(nr, nc))
+                        {
+                            let peers1 = board.peer_coords(nr, nc);
+                            let changed = peers0.iter().filter(|p| peers1.contains(p)).try_fold(
+                                false,
+                                |acc, &(rr, cc)| match board.eliminate_candidate(
+                                    rr,
+                                    cc,
+                                    start_digit,
+                                ) {
+                                    Some(true) => Ok(true),
+                                    Some(false) => Ok(acc),
+                                    None => Err(SolverError::Contradiction { row: rr, col: cc }),
+                                },
+                            )?;
+                            if changed {
+                                return Ok(true);
                             }
-                            let next_digit = cand.iter().find(|&d| d != node.digit).unwrap();
+                        }
 
-                            if (nr, nc) != (r0, c0)
-                                && next_digit == start_digit
-                                && peers0.contains(&(nr, nc))
-                            {
-                                let peers1 = board.peer_coords(nr, nc);
-                                let changed = peers0
-                                    .iter()
-                                    .filter(|p| peers1.contains(p))
-                                    .try_fold(false, |acc, &(rr, cc)| {
-                                        match board.eliminate_candidate(rr, cc, start_digit) {
-                                            Some(true) => Ok(true),
-                                            Some(false) => Ok(acc),
-                                            None => {
-                                                Err(SolverError::Contradiction { row: rr, col: cc })
-                                            }
-                                        }
-                                    })?;
-                                if changed {
-                                    return Ok(true);
-                                }
-                            }
-
-                            if visited.insert((nr, nc, next_digit)) {
-                                queue.push_back(Node {
-                                    r: nr,
-                                    c: nc,
-                                    digit: next_digit,
-                                    prev: node.digit,
-                                });
-                            }
+                        if visited.insert((nr, nc, next_digit)) {
+                            queue.push_back(Node {
+                                r: nr,
+                                c: nc,
+                                digit: next_digit,
+                                prev: node.digit,
+                            });
                         }
                     }
                 }
             }
         }
+
         Ok(false)
     }
 }

--- a/src/strategy/advanced/xy_wing.rs
+++ b/src/strategy/advanced/xy_wing.rs
@@ -12,48 +12,49 @@ impl Strategy for XYWing {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for r in crate::board::row_indices() {
-            for c in crate::board::col_indices() {
-                let pivot = board.candidates(r, c);
-                if pivot.len() != PAIR_LEN {
+        let cells: Vec<_> = board.unsolved_cells().collect();
+        for (r, c) in cells {
+            let pivot = board.candidates(r, c);
+            if pivot.len() != PAIR_LEN {
+                continue;
+            }
+
+            let mut digits = pivot.iter();
+            let a = digits.next().unwrap();
+            let b = digits.next().unwrap();
+            let peers = board.peer_coords(r, c);
+
+            for &(r1, c1) in &peers {
+                let cand1 = board.candidates(r1, c1);
+                if cand1.len() != PAIR_LEN || !cand1.contains(a) || cand1.contains(b) {
                     continue;
                 }
-                let mut digits = pivot.iter();
-                let a = digits.next().unwrap();
-                let b = digits.next().unwrap();
-                let peers = board.peer_coords(r, c);
+                let z = cand1.iter().find(|&d| d != a).unwrap();
 
-                for &(r1, c1) in &peers {
-                    let cand1 = board.candidates(r1, c1);
-                    if cand1.len() != PAIR_LEN || !cand1.contains(a) || cand1.contains(b) {
+                for &(r2, c2) in &peers {
+                    if (r2, c2) == (r1, c1) {
                         continue;
                     }
-                    let z = cand1.iter().find(|&d| d != a).unwrap();
-                    for &(r2, c2) in &peers {
-                        if (r2, c2) == (r1, c1) {
-                            continue;
-                        }
-                        let cand2 = board.candidates(r2, c2);
-                        if cand2.len() != PAIR_LEN || !cand2.contains(b) || cand2.contains(a) {
-                            continue;
-                        }
-                        if !cand2.contains(z) {
-                            continue;
-                        }
+                    let cand2 = board.candidates(r2, c2);
+                    if cand2.len() != PAIR_LEN || !cand2.contains(b) || cand2.contains(a) {
+                        continue;
+                    }
+                    if !cand2.contains(z) {
+                        continue;
+                    }
 
-                        let peers1 = board.peer_coords(r1, c1);
-                        let peers2 = board.peer_coords(r2, c2);
-                        let changed = peers1.iter().filter(|p| peers2.contains(p)).try_fold(
-                            false,
-                            |acc, &(rr, cc)| match board.eliminate_candidate(rr, cc, z) {
-                                Some(true) => Ok(true),
-                                Some(false) => Ok(acc),
-                                None => Err(SolverError::Contradiction { row: rr, col: cc }),
-                            },
-                        )?;
-                        if changed {
-                            return Ok(true);
-                        }
+                    let peers1 = board.peer_coords(r1, c1);
+                    let peers2 = board.peer_coords(r2, c2);
+                    let changed = peers1.iter().filter(|p| peers2.contains(p)).try_fold(
+                        false,
+                        |acc, &(rr, cc)| match board.eliminate_candidate(rr, cc, z) {
+                            Some(true) => Ok(true),
+                            Some(false) => Ok(acc),
+                            None => Err(SolverError::Contradiction { row: rr, col: cc }),
+                        },
+                    )?;
+                    if changed {
+                        return Ok(true);
                     }
                 }
             }

--- a/src/strategy/advanced/xyz_wing.rs
+++ b/src/strategy/advanced/xyz_wing.rs
@@ -12,56 +12,57 @@ impl Strategy for XYZWing {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        for r in crate::board::row_indices() {
-            for c in crate::board::col_indices() {
-                let pivot = board.candidates(r, c);
-                if pivot.len() != TRIPLE_LEN {
-                    continue;
-                }
-                let digits: Vec<u8> = pivot.iter().collect();
-                let peers = board.peer_coords(r, c);
+        let cells: Vec<_> = board.unsolved_cells().collect();
+        for (r, c) in cells {
+            let pivot = board.candidates(r, c);
+            if pivot.len() != TRIPLE_LEN {
+                continue;
+            }
 
-                for i in 0..TRIPLE_LEN {
-                    let z = digits[i];
-                    let x = digits[(i + 1) % TRIPLE_LEN];
-                    let y = digits[(i + 2) % TRIPLE_LEN];
-                    let w1s: Vec<_> = peers
-                        .iter()
-                        .copied()
-                        .filter(|&(r1, c1)| board.candidates(r1, c1) == vec![x, z])
-                        .collect();
-                    let w2s: Vec<_> = peers
-                        .iter()
-                        .copied()
-                        .filter(|&(r2, c2)| board.candidates(r2, c2) == vec![y, z])
-                        .collect();
-                    for (r1, c1) in &w1s {
-                        for (r2, c2) in &w2s {
-                            if (r1, c1) == (r2, c2) {
-                                continue;
-                            }
-                            let peers1 = board.peer_coords(*r1, *c1);
-                            let peers2 = board.peer_coords(*r2, *c2);
-                            let changed = peers1
-                                .iter()
-                                .filter(|p| peers2.contains(p) && peers.contains(p))
-                                .try_fold(false, |acc, &(rr, cc)| {
-                                    match board.eliminate_candidate(rr, cc, z) {
-                                        Some(true) => Ok(true),
-                                        Some(false) => Ok(acc),
-                                        None => {
-                                            Err(SolverError::Contradiction { row: rr, col: cc })
-                                        }
-                                    }
-                                })?;
-                            if changed {
-                                return Ok(true);
-                            }
+            let digits: Vec<u8> = pivot.iter().collect();
+            let peers = board.peer_coords(r, c);
+
+            for i in 0..TRIPLE_LEN {
+                let z = digits[i];
+                let x = digits[(i + 1) % TRIPLE_LEN];
+                let y = digits[(i + 2) % TRIPLE_LEN];
+
+                let w1s: Vec<_> = peers
+                    .iter()
+                    .copied()
+                    .filter(|&(r1, c1)| board.candidates(r1, c1) == vec![x, z])
+                    .collect();
+                let w2s: Vec<_> = peers
+                    .iter()
+                    .copied()
+                    .filter(|&(r2, c2)| board.candidates(r2, c2) == vec![y, z])
+                    .collect();
+
+                for (r1, c1) in &w1s {
+                    for (r2, c2) in &w2s {
+                        if (r1, c1) == (r2, c2) {
+                            continue;
+                        }
+                        let peers1 = board.peer_coords(*r1, *c1);
+                        let peers2 = board.peer_coords(*r2, *c2);
+                        let changed = peers1
+                            .iter()
+                            .filter(|p| peers2.contains(p) && peers.contains(p))
+                            .try_fold(false, |acc, &(rr, cc)| {
+                                match board.eliminate_candidate(rr, cc, z) {
+                                    Some(true) => Ok(true),
+                                    Some(false) => Ok(acc),
+                                    None => Err(SolverError::Contradiction { row: rr, col: cc }),
+                                }
+                            })?;
+                        if changed {
+                            return Ok(true);
                         }
                     }
                 }
             }
         }
+
         Ok(false)
     }
 }

--- a/src/strategy/advanced/y_wing.rs
+++ b/src/strategy/advanced/y_wing.rs
@@ -12,8 +12,9 @@ impl Strategy for YWing {
     }
 
     fn apply(&self, board: &mut Board) -> Result<bool, SolverError> {
-        if crate::board::row_indices()
-            .flat_map(|r| crate::board::col_indices().map(move |c| (r, c)))
+        let cells: Vec<_> = board.unsolved_cells().collect();
+        if cells
+            .into_iter()
             .find_map(|(r, c)| {
                 let pivot = board.candidates(r, c);
                 if pivot.len() != PAIR_LEN {

--- a/tests/board_iteration.rs
+++ b/tests/board_iteration.rs
@@ -69,3 +69,12 @@ fn box_iteration_helpers() {
     board.for_each_box_digit(|_, _| combos += 1);
     assert_eq!(combos, 81);
 }
+
+#[test]
+fn unsolved_cells_iterates_only_empty() {
+    let puzzle = format!("1{}", ".".repeat(80));
+    let board = Board::parse(&puzzle).unwrap();
+    let coords: Vec<_> = board.unsolved_cells().collect();
+    assert_eq!(coords.len(), 80);
+    assert!(!coords.contains(&(0, 0)));
+}


### PR DESCRIPTION
## Summary
- provide `unsolved_cells()` iterator on `Board`
- refactor advanced strategies to use the new API
- adjust strategies to avoid borrow checker errors
- add unit test covering unsolved cell iteration

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68754af7450c8324853971e731c97a00